### PR TITLE
fix: disable SMS failover in whatsapp-send-text tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,7 +235,7 @@ server.registerTool(
   async (args: any) => {
     const { to, message } = args as { to: string; message: string };
     try {
-      const { messageUUID } = await sendWhatsAppText(to, message, true);
+      const { messageUUID } = await sendWhatsAppText(to, message, false);
 
       return {
         content: [


### PR DESCRIPTION
## Summary

Fixes a bug where the `whatsapp-send-text` tool was incorrectly enabling SMS failover, making it functionally identical to `whatsapp-send-text-with-sms-failover`.

## Changes

- Changed `src/index.ts` line 238: `sendWhatsAppText(to, message, true)` → `sendWhatsAppText(to, message, false)`

## Behavior After Fix

**Before:**
- `whatsapp-send-text` would silently fall back to SMS if WhatsApp delivery failed
- Both WhatsApp tools behaved identically

**After:**
- `whatsapp-send-text` - WhatsApp-only delivery (fails if recipient can't receive WhatsApp)
- `whatsapp-send-text-with-sms-failover` - WhatsApp with automatic SMS fallback

## Impact

This is a bug fix that restores the documented behavior. Users who relied on the unintended SMS fallback should switch to using `whatsapp-send-text-with-sms-failover` instead.

## Test Plan

- [x] Code compiles successfully (`npm run build`)